### PR TITLE
Add two legacy posts from old blog

### DIFF
--- a/app/blog/posts/shellshock.mdx
+++ b/app/blog/posts/shellshock.mdx
@@ -1,0 +1,33 @@
+---
+title:  'Shellshock'
+publishedAt:   2014-10-02
+summary: Learn about ShellShock and how to address it in Bash v3 on Mac OS X Mavericks
+---
+
+If you haven't already heard, ShellShock is the name of a recent vulnerability [CVE-2014-6271][CVE] discovered in [GNU Bash][GNU Bash]. Apple ships Bash v3 in the latest version of their operating system, [OS X Mavericks][OS X]. 
+
+There are a number of ways to determine if your copy of Bash is vulnerable. The best one I've seen is [bashcheck][bashcheck]. It only checks Bash for the original ShellShock vulnerability but also ones discovered after the initial "fix" was released. Excecuting the `bashcheck` script tests the default Bash installation on the machine. Here's some sample output:
+
+```
+Testing /opt/local/bin/bash ...
+GNU bash, version 4.3.28(1)-release (x86_64-apple-darwin13.4.0)
+
+Variable function parser pre/suffixed [%%, upstream], bugs not explitable
+Not vulnerable to CVE-2014-6271 (original shellshock)
+Not vulnerable to CVE-2014-7169 (taviso bug)
+Not vulnerable to CVE-2014-7186 (redir_stack bug)
+Test for CVE-2014-7187 not reliable without address sanitizer
+Found non-exploitable CVE-2014-6277 (lcamtuf bug #1)
+Found non-exploitable CVE-2014-6278 (lcamtuf bug #2)
+```
+
+Keen observers may have noticed that the script also outputs the location of the Bash executable. In the case above, it's `/opt/local/bin/bash` as opposed to `/bin/bash`. I use the [MacPorts][MacPorts] version of Bash instead of Apple's include Bash since Apple has a history of included outdated or modified versions of Unix utitlies in their operating system. While Apple has released a [patch][Apple Bash update], it's still a major version way from the latest available version.
+
+Whichever way you go, make sure you apply the patch!
+
+[bashcheck]:          https://github.com/hannob/bashcheck
+[CVE]:                http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6271
+[GNU Bash]:           https://www.gnu.org/software/bash/
+[OS X]:               http://www.apple.com/osx/
+[MacPorts]:           http://www.macports.org
+[Apple Bash update]:  http://support.apple.com/kb/DL1769

--- a/app/blog/pythonMacPorts.mdx
+++ b/app/blog/pythonMacPorts.mdx
@@ -1,0 +1,98 @@
+---
+title:  'Python and friends on MacPorts'
+publishedAt:   2014-10-06
+summary: Learn how to install Python, pip and virtualenv on Mac OS X using MacPorts
+---
+During the course of my day job, I needed to install Python and pip. For those using MacPorts, below is the method I've used to accomplish the task. I used Python v2.7 since I hear v3 has some backward compatibility issues.
+
+For each component, I perform a `search`, `install`, `select --list` and then `select --set`.
+
+# Python
+
+## Search available Python versions
+
+```
+sudo port search python2*
+```
+
+## Install Python v2.7.8
+
+From the list of Pythons that show up, I chose to install python27:
+
+```
+sudo port install python27
+```
+
+## List installed Pythons
+
+```
+sudo port select --list python
+```
+
+A number of Apple installations should show up along with the Python that was installed in the last step (python27)
+
+## Set active Python version
+
+Set the MacPorts Python 2.7.x installation as the default Python system-wide:
+
+```
+sudo port select --set python python27
+```
+
+# pip
+
+## Search available pip versions:
+
+```
+sudo port search py*-pip
+```
+
+## Install pip v1.5.6
+
+```
+sudo port install py27-pip
+```
+
+## List installed pips
+
+```
+sudo port select --list pip
+```
+
+**Note:** If you get an error executing the above, try forcing the activation by executing `sudo port -f activate py27-pip`
+
+## Set active pip version
+
+```
+sudo port select --set pip pip27
+```
+
+# virtualenv
+
+## Search available Python virtual environments
+
+```
+sudo port search py*-virtualenv
+```
+
+## Install virtualenv 1.11.6 for Python v2.7
+
+```
+sudo port install py27-virtualenv
+```
+
+## List installed virtualenvs
+
+```
+sudo port select --list virtualenv
+```
+
+
+## Set active virtualenv
+```
+sudo port select --set virtualenv virtualenv27
+```
+
+Following the above should give you Python, pip and virtualenv for Python 2.7.
+
+As a bonus, MacPorts also ensures there's an `easy_install` version that's specific to your MacPorts Python installation. In the above case, it should be located in `<MacPorts_Home>/bin/easy_install-2.7`. If you can't remember the location of your MacPorts home directory, you can use bash completion by having it complete `easy_install`.


### PR DESCRIPTION
This pull request includes two new blog posts about ShellShock and Python installation using MacPorts. The most important changes are the addition of markdown files with detailed instructions and information for each topic.

New blog posts:

* [`app/blog/posts/shellshock.mdx`](diffhunk://#diff-5ad3d184d8d6353c2aceb2990ebadb892b2b94a40befbe3181114818435de86dR1-R33): Added a detailed blog post about the ShellShock vulnerability, including how to check for it and apply necessary patches on Mac OS X Mavericks.

* [`app/blog/pythonMacPorts.mdx`](diffhunk://#diff-74308066177d7f1b453120ad3df717dd8d9cbcab73091d9abbd8ca415f2802c1R1-R98): Added a comprehensive guide on installing Python, pip, and virtualenv using MacPorts on Mac OS X, including step-by-step instructions for each component.